### PR TITLE
Simplify permission interface

### DIFF
--- a/src/Rbac/Permission/PermissionInterface.php
+++ b/src/Rbac/Permission/PermissionInterface.php
@@ -9,8 +9,6 @@
 
 namespace Rbac\Permission;
 
-use Rbac\Role\RoleInterface;
-
 /**
  * Interface for permission
  */
@@ -22,13 +20,6 @@ interface PermissionInterface
      * @return string|int
      */
     public function getName();
-
-    /**
-     * Get roles associated with the permission
-     *
-     * @return RoleInterface[]
-     */
-    public function getRoles();
 
     /**
      * Cast the permission to a string (must return the permission name)


### PR DESCRIPTION
ping @arekkas @spiffyjr @danizord

I need your feedback on this. I'm actually thinking about reducing the interface of Permission so that we don't need to implement the getRoles. The idea is to remove the need of maintaining bi-directional association (which simplify a lot in Doctrine).

I can't really find a case where you would like to traverse the permission from the permission to the roles.
