### PR TITLE
Traversal strategies

### DIFF
--- a/src/Rbac/Rbac.php
+++ b/src/Rbac/Rbac.php
@@ -11,6 +11,7 @@ namespace Rbac;
 
 use Rbac\Permission\PermissionInterface;
 use Rbac\Role\RoleInterface;
+use Rbac\Traversal\Strategy\GeneratorStrategy;
 use Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy;
 use Rbac\Traversal\Strategy\TraversalStrategyInterface;
 use Traversable;
@@ -30,7 +31,13 @@ class Rbac
      */
     public function __construct(TraversalStrategyInterface $strategy = null)
     {
-        $this->traversalStrategy = $strategy ?: new RecursiveRoleIteratorStrategy;
+        if (null !== $strategy) {
+            $this->traversalStrategy = $strategy;
+        } elseif (version_compare(PHP_VERSION, '5.5.0', '>=')) {
+            $this->traversalStrategy = new GeneratorStrategy();
+        } else {
+            $this->traversalStrategy = new RecursiveRoleIteratorStrategy();
+        }
     }
 
     /**

--- a/src/Rbac/Rbac.php
+++ b/src/Rbac/Rbac.php
@@ -3,48 +3,56 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Rbac;
 
 use Rbac\Permission\PermissionInterface;
-use Rbac\Role\HierarchicalRoleInterface;
 use Rbac\Role\RoleInterface;
-use RecursiveIteratorIterator;
+use Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy;
+use Rbac\Traversal\Strategy\TraversalStrategyInterface;
+use Traversable;
 
 /**
- * Rbac object. It is used to check a permission against a role
+ * Rbac object. It is used to check a permission against roles
  */
 class Rbac
 {
     /**
-     * Determines if access is granted by checking the role and child roles for permission.
+     * @var TraversalStrategyInterface
+     */
+    protected $traversalStrategy;
+
+    /**
+     * @param null|TraversalStrategyInterface $strategy
+     */
+    public function __construct(TraversalStrategyInterface $strategy = null)
+    {
+        $this->traversalStrategy = ($strategy) ? $strategy : new RecursiveRoleIteratorStrategy;
+    }
+
+    /**
+     * Determines if access is granted by checking the roles for permission.
      *
-     * @param  RoleInterface              $role
-     * @param  PermissionInterface|string $permission
+     * @param  RoleInterface|RoleInterface[]|Traversable $roles
+     * @param  PermissionInterface|string                $permission
      * @return bool
      */
-    public function isGranted(RoleInterface $role, $permission)
+    public function isGranted($roles, $permission)
     {
         $permission = (string) $permission;
 
-        // First check directly the role
-        if ($role->hasPermission($permission)) {
-            return true;
+        if ($roles instanceof RoleInterface) {
+            $roles = [$roles];
         }
 
-        // Otherwise, we recursively check each children only if it's a hierarchical role
-        if (!$role instanceof HierarchicalRoleInterface) {
-            return false;
-        }
+        $iterator = $this->traversalStrategy->traverseRoles($roles);
 
-        $iteratorIterator = new RecursiveIteratorIterator($role, RecursiveIteratorIterator::SELF_FIRST);
-
-        foreach ($iteratorIterator as $child) {
-            /** @var RoleInterface $child */
-            if ($child->hasPermission($permission)) {
+        foreach ($iterator as $role) {
+            /* @var RoleInterface $role */
+            if ($role->hasPermission($permission)) {
                 return true;
             }
         }

--- a/src/Rbac/Rbac.php
+++ b/src/Rbac/Rbac.php
@@ -30,7 +30,7 @@ class Rbac
      */
     public function __construct(TraversalStrategyInterface $strategy = null)
     {
-        $this->traversalStrategy = ($strategy) ? $strategy : new RecursiveRoleIteratorStrategy;
+        $this->traversalStrategy = $strategy ?: new RecursiveRoleIteratorStrategy;
     }
 
     /**

--- a/src/Rbac/Rbac.php
+++ b/src/Rbac/Rbac.php
@@ -48,7 +48,7 @@ class Rbac
             $roles = [$roles];
         }
 
-        $iterator = $this->traversalStrategy->traverseRoles($roles);
+        $iterator = $this->traversalStrategy->getRolesIterator($roles);
 
         foreach ($iterator as $role) {
             /* @var RoleInterface $role */

--- a/src/Rbac/Role/HierarchicalRole.php
+++ b/src/Rbac/Role/HierarchicalRole.php
@@ -22,6 +22,14 @@ class HierarchicalRole extends Role implements HierarchicalRoleInterface
     /**
      * {@inheritDoc}
      */
+    public function hasChildren()
+    {
+        return !empty($this->children);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getChildren()
     {
         return $this->children;

--- a/src/Rbac/Role/HierarchicalRole.php
+++ b/src/Rbac/Role/HierarchicalRole.php
@@ -3,13 +3,11 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Rbac\Role;
-
-use RecursiveIterator;
 
 /**
  * Simple implementation for a hierarchical role
@@ -22,77 +20,20 @@ class HierarchicalRole extends Role implements HierarchicalRoleInterface
     protected $children = [];
 
     /**
-     * @var int
-     */
-    protected $index = 0;
-
-    /**
-     * {@inheritDoc}
-     */
-    public function addChild(RoleInterface $child)
-    {
-        $this->children[] = $child;
-    }
-
-    /*
-     * --------------------------------------------------------------------------------
-     * RecursiveIterator implementation
-     * --------------------------------------------------------------------------------
-     */
-
-    /**
-     * {@inheritDoc}
-     */
-    public function current()
-    {
-        return $this->children[$this->index];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function next()
-    {
-        $this->index++;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function key()
-    {
-        return $this->index;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function valid()
-    {
-        return isset($this->children[$this->index]);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function rewind()
-    {
-        $this->index = 0;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function getChildren()
     {
-        return $this->children[$this->index];
+        return $this->children;
     }
 
     /**
-     * {@inheritDoc}
+     * Add a child role
+     *
+     * @param RoleInterface $child
      */
-    public function hasChildren()
+    public function addChild(RoleInterface $child)
     {
-        return $this->valid() && $this->current() instanceof RecursiveIterator;
+        $this->children[] = $child;
     }
 }

--- a/src/Rbac/Role/HierarchicalRole.php
+++ b/src/Rbac/Role/HierarchicalRole.php
@@ -42,6 +42,6 @@ class HierarchicalRole extends Role implements HierarchicalRoleInterface
      */
     public function addChild(RoleInterface $child)
     {
-        $this->children[] = $child;
+        $this->children[$child->getName()] = $child;
     }
 }

--- a/src/Rbac/Role/HierarchicalRoleInterface.php
+++ b/src/Rbac/Role/HierarchicalRoleInterface.php
@@ -1,30 +1,27 @@
 <?php
-/*
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/**
+ * Zend Framework (http://framework.zend.com/)
  *
- * This software consists of voluntary contributions made by many individuals
- * and is licensed under the MIT license.
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Rbac\Role;
 
-use RecursiveIterator;
+use Traversable;
 
 /**
  * Interface for a hierarchical role
  *
- * A hierarchical role is a role that can have children and be recursively traversed.
+ * A hierarchical role is a role that can have children.
  */
-interface HierarchicalRoleInterface extends RoleInterface, RecursiveIterator
+interface HierarchicalRoleInterface extends RoleInterface
 {
+    /**
+     * Get child roles
+     *
+     * @return array|RoleInterface[]|Traversable
+     */
+    public function getChildren();
 }

--- a/src/Rbac/Role/HierarchicalRoleInterface.php
+++ b/src/Rbac/Role/HierarchicalRoleInterface.php
@@ -19,6 +19,13 @@ use Traversable;
 interface HierarchicalRoleInterface extends RoleInterface
 {
     /**
+     * Check if the role has children
+     *
+     * @return bool
+     */
+    public function hasChildren();
+
+    /**
      * Get child roles
      *
      * @return array|RoleInterface[]|Traversable

--- a/src/Rbac/Traversal/RecursiveRoleIterator.php
+++ b/src/Rbac/Traversal/RecursiveRoleIterator.php
@@ -13,9 +13,24 @@ use ArrayIterator;
 use Rbac\Role\HierarchicalRoleInterface;
 use Rbac\Role\RoleInterface;
 use RecursiveIterator;
+use Traversable;
 
 class RecursiveRoleIterator extends ArrayIterator implements RecursiveIterator
 {
+    /**
+     * Override constructor to accept {@link Traversable} as well
+     *
+     * @param RoleInterface[]|Traversable
+     */
+    public function __construct($roles)
+    {
+        if ($roles instanceof Traversable) {
+            $roles = iterator_to_array($roles);
+        }
+
+        parent::__construct($roles);
+    }
+
     /**
      * @return bool
      */

--- a/src/Rbac/Traversal/RecursiveRoleIterator.php
+++ b/src/Rbac/Traversal/RecursiveRoleIterator.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Rbac\Traversal;
+
+use ArrayIterator;
+use Rbac\Role\HierarchicalRoleInterface;
+use Rbac\Role\RoleInterface;
+use RecursiveIterator;
+
+class RecursiveRoleIterator extends ArrayIterator implements RecursiveIterator
+{
+    /**
+     * @return bool
+     */
+    public function valid()
+    {
+        return $this->current() instanceof RoleInterface;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasChildren()
+    {
+        $current = $this->current();
+
+        if (!$current instanceof HierarchicalRoleInterface) {
+            return false;
+        }
+
+        if (empty($current->getChildren())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return RecursiveRoleIterator
+     */
+    public function getChildren()
+    {
+        return new RecursiveRoleIterator($this->current()->getChildren());
+    }
+}

--- a/src/Rbac/Traversal/RecursiveRoleIterator.php
+++ b/src/Rbac/Traversal/RecursiveRoleIterator.php
@@ -50,11 +50,7 @@ class RecursiveRoleIterator extends ArrayIterator implements RecursiveIterator
             return false;
         }
 
-        if (empty($current->getChildren())) {
-            return false;
-        }
-
-        return true;
+        return $current->hasChildren();
     }
 
     /**

--- a/src/Rbac/Traversal/Strategy/GeneratorStrategy.php
+++ b/src/Rbac/Traversal/Strategy/GeneratorStrategy.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Rbac\Traversal\Strategy;
+
+use Generator;
+use Rbac\Role\HierarchicalRoleInterface;
+use Rbac\Role\RoleInterface;
+use Traversable;
+
+/**
+ * Traverses roles recursively with PHP 5.5 generators
+ * Requires PHP >= 5.5
+ */
+class GeneratorStrategy implements TraversalStrategyInterface
+{
+    /**
+     * @param  RoleInterface[]|Traversable $roles
+     * @return Generator
+     */
+    public function traverseRoles($roles)
+    {
+        foreach ($roles as $role) {
+            yield $role;
+
+            if (!$role instanceof HierarchicalRoleInterface) {
+                continue;
+            }
+
+            $children = $role->getChildren();
+
+            foreach ($this->traverseRoles($children) as $child) {
+                yield $child;
+            }
+        }
+    }
+}

--- a/src/Rbac/Traversal/Strategy/GeneratorStrategy.php
+++ b/src/Rbac/Traversal/Strategy/GeneratorStrategy.php
@@ -15,7 +15,7 @@ use Rbac\Role\RoleInterface;
 use Traversable;
 
 /**
- * Traverses roles recursively with PHP 5.5 generators
+ * Recursively traverse roles using generator
  * Requires PHP >= 5.5
  */
 class GeneratorStrategy implements TraversalStrategyInterface
@@ -24,7 +24,7 @@ class GeneratorStrategy implements TraversalStrategyInterface
      * @param  RoleInterface[]|Traversable $roles
      * @return Generator
      */
-    public function traverseRoles($roles)
+    public function getRolesIterator($roles)
     {
         foreach ($roles as $role) {
             yield $role;
@@ -33,9 +33,9 @@ class GeneratorStrategy implements TraversalStrategyInterface
                 continue;
             }
 
-            $children = $role->getChildren();
+            $children = $this->getRolesIterator($role->getChildren());
 
-            foreach ($this->traverseRoles($children) as $child) {
+            foreach ($children as $child) {
                 yield $child;
             }
         }

--- a/src/Rbac/Traversal/Strategy/RecursiveRoleIteratorStrategy.php
+++ b/src/Rbac/Traversal/Strategy/RecursiveRoleIteratorStrategy.php
@@ -14,8 +14,7 @@ use Rbac\Traversal\RecursiveRoleIterator;
 use RecursiveIteratorIterator;
 
 /**
- * Traverses roles recursively a {@link RecursiveRoleIterator}
- * wrapped by a {@link RecursiveIteratorIterator}
+ * Create a {@link RecursiveRoleIterator} and wrap it into a {@link RecursiveIteratorIterator}
  */
 class RecursiveRoleIteratorStrategy implements TraversalStrategyInterface
 {
@@ -23,7 +22,7 @@ class RecursiveRoleIteratorStrategy implements TraversalStrategyInterface
      * @param  RoleInterface[]           $roles
      * @return RecursiveIteratorIterator
      */
-    public function traverseRoles($roles)
+    public function getRolesIterator($roles)
     {
         return new RecursiveIteratorIterator(
             new RecursiveRoleIterator($roles),

--- a/src/Rbac/Traversal/Strategy/RecursiveRoleIteratorStrategy.php
+++ b/src/Rbac/Traversal/Strategy/RecursiveRoleIteratorStrategy.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Rbac\Traversal\Strategy;
+
+use Rbac\Role\RoleInterface;
+use Rbac\Traversal\RecursiveRoleIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Traverses roles recursively a {@link RecursiveRoleIterator}
+ * wrapped by a {@link RecursiveIteratorIterator}
+ */
+class RecursiveRoleIteratorStrategy implements TraversalStrategyInterface
+{
+    /**
+     * @param  RoleInterface[]           $roles
+     * @return RecursiveIteratorIterator
+     */
+    public function traverseRoles($roles)
+    {
+        return new RecursiveIteratorIterator(
+            new RecursiveRoleIterator($roles),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+    }
+}

--- a/src/Rbac/Traversal/Strategy/TraversalStrategyInterface.php
+++ b/src/Rbac/Traversal/Strategy/TraversalStrategyInterface.php
@@ -21,5 +21,5 @@ interface TraversalStrategyInterface
      * @param  RoleInterface[]|Traversable
      * @return Traversable
      */
-    public function traverseRoles($roles);
+    public function getRolesIterator($roles);
 }

--- a/src/Rbac/Traversal/Strategy/TraversalStrategyInterface.php
+++ b/src/Rbac/Traversal/Strategy/TraversalStrategyInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Rbac\Traversal\Strategy;
+
+use Rbac\Role\RoleInterface;
+use Traversable;
+
+/**
+ * Interface for a traversal strategy
+ */
+interface TraversalStrategyInterface
+{
+    /**
+     * @param  RoleInterface[]|Traversable
+     * @return Traversable
+     */
+    public function traverseRoles($roles);
+}

--- a/tests/RbacTest/RbacTest.php
+++ b/tests/RbacTest/RbacTest.php
@@ -38,11 +38,13 @@ class RbacTest extends TestCase
     {
         $rbac = new Rbac;
 
-        $this->assertAttributeInstanceOf(
-            'Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy',
-            'traversalStrategy',
-            $rbac
-        );
+        if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
+            $default = 'Rbac\Traversal\Strategy\GeneratorStrategy';
+        } else {
+            $default = 'Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy';
+        }
+
+        $this->assertAttributeInstanceOf($default, 'traversalStrategy', $rbac);
     }
 
     /**

--- a/tests/RbacTest/RbacTest.php
+++ b/tests/RbacTest/RbacTest.php
@@ -67,7 +67,7 @@ class RbacTest extends TestCase
 
         $traversalStrategy = $this->getMock('Rbac\Traversal\Strategy\TraversalStrategyInterface');
         $traversalStrategy->expects($this->once())
-            ->method('traverseRoles')
+            ->method('getRolesIterator')
             ->with($this->equalTo([$role]))
             ->will($this->returnValue(new ArrayIterator([])));
 
@@ -83,7 +83,7 @@ class RbacTest extends TestCase
     {
         $traversalStrategy = $this->getMock('Rbac\Traversal\Strategy\TraversalStrategyInterface');
         $traversalStrategy->expects($this->once())
-            ->method('traverseRoles')
+            ->method('getRolesIterator')
             ->will($this->returnValue(new ArrayIterator([])));
 
         $rbac = new Rbac($traversalStrategy);

--- a/tests/RbacTest/Role/HierarchicalRoleTest.php
+++ b/tests/RbacTest/Role/HierarchicalRoleTest.php
@@ -3,45 +3,49 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Permissions
  */
 
 namespace RbacTest;
 
+use PHPUnit_Framework_TestCase as TestCase;
 use Rbac\Role\HierarchicalRole;
 
 /**
- * @covers \Rbac\Role\HierarchicalRole
- * @group Coverage
+ * @covers Rbac\Role\HierarchicalRole
+ * @group  Coverage
  */
-class HierarchicalRoleTest extends \PHPUnit_Framework_TestCase
+class HierarchicalRoleTest extends TestCase
 {
+    /**
+     * @covers Rbac\Role\HierarchicalRole::addChild
+     */
     public function testCanAddChild()
     {
-        $role  = new HierarchicalRole('php');
-        $child = new HierarchicalRole('ror');
+        $role  = new HierarchicalRole('role');
+        $child = new HierarchicalRole('child');
+
         $role->addChild($child);
 
-        $count = 0;
-
-        foreach ($role as $child) {
-            $count++;
-        }
-
-        $this->assertEquals(1, $count);
+        $this->assertCount(1, $role->getChildren());
     }
 
-    public function testDontTestChildPermission()
+    /**
+     * @covers Rbac\Role\HierarchicalRole::getChildren
+     */
+    public function testCanGetChildren()
     {
-        $role  = new HierarchicalRole('php');
-        $child = new HierarchicalRole('ror');
+        $role   = new HierarchicalRole('role');
+        $child1 = new HierarchicalRole('child 1');
+        $child2 = new HierarchicalRole('child 2');
 
-        $role->addChild($role);
-        $child->addPermission('debug');
+        $role->addChild($child1);
+        $role->addChild($child2);
 
-        $this->assertTrue($child->hasPermission('debug'));
-        $this->assertFalse($role->hasPermission('debug'));
+        $children = $role->getChildren();
+
+        $this->assertCount(2, $children);
+        $this->assertContainsOnlyInstancesOf('Rbac\Role\HierarchicalRole', $children);
     }
 }

--- a/tests/RbacTest/Role/HierarchicalRoleTest.php
+++ b/tests/RbacTest/Role/HierarchicalRoleTest.php
@@ -32,6 +32,20 @@ class HierarchicalRoleTest extends TestCase
     }
 
     /**
+     * @covers Rbac\Role\HierarchicalRole::hasChildren
+     */
+    public function testHasChildren()
+    {
+        $role = new HierarchicalRole('role');
+
+        $this->assertFalse($role->hasChildren());
+
+        $role->addChild(new HierarchicalRole('child'));
+
+        $this->assertTrue($role->hasChildren());
+    }
+
+    /**
      * @covers Rbac\Role\HierarchicalRole::getChildren
      */
     public function testCanGetChildren()

--- a/tests/RbacTest/Traversal/RecursiveRoleIteratorTest.php
+++ b/tests/RbacTest/Traversal/RecursiveRoleIteratorTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace RbacTest\Traversal;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Rbac\Role\HierarchicalRole;
+use Rbac\Role\Role;
+use Rbac\Traversal\RecursiveRoleIterator;
+use stdClass;
+
+/**
+ * @covers Rbac\Traversal\RecursiveRoleIterator
+ * @group  Coverage
+ */
+class RecursiveRoleIteratorTest extends TestCase
+{
+    /**
+     * @covers Rbac\Traversal\RecursiveRoleIterator::valid
+     */
+    public function testValidateRoleInterface()
+    {
+        $foo      = new Role('Foo');
+        $roles    = [$foo, new stdClass];
+        $iterator = new RecursiveRoleIterator($roles);
+
+        $this->assertSame($iterator->current(), $foo);
+        $this->assertTrue($iterator->valid());
+
+        $iterator->next();
+
+        $this->assertFalse($iterator->valid());
+    }
+
+    /**
+     * @covers Rbac\Traversal\RecursiveRoleIterator::hasChildren
+     */
+    public function testHasChildrenReturnsFalseIfRoleIsNotHierarchical()
+    {
+        $foo      = new Role('Foo');
+        $roles    = [$foo];
+        $iterator = new RecursiveRoleIterator($roles);
+
+        $this->assertFalse($iterator->hasChildren());
+    }
+
+    /**
+     * @covers Rbac\Traversal\RecursiveRoleIterator::hasChildren
+     */
+    public function testHasChildrenReturnsFalseIfRoleChildrenIsEmpty()
+    {
+        $bar      = new HierarchicalRole('Bar');
+        $roles    = [$bar];
+        $iterator = new RecursiveRoleIterator($roles);
+
+        $this->assertFalse($iterator->hasChildren());
+    }
+
+    /**
+     * @covers Rbac\Traversal\RecursiveRoleIterator::hasChildren
+     */
+    public function testHasChildrenReturnsTrueIfRoleHasChildren()
+    {
+        $baz = new HierarchicalRole('Baz');
+        $baz->addChild(new Role('Foo'));
+
+        $roles    = [$baz];
+        $iterator = new RecursiveRoleIterator($roles);
+
+        $this->assertTrue($iterator->hasChildren());
+    }
+
+    /**
+     * @covers Rbac\Traversal\RecursiveRoleIterator::getChildren
+     */
+    public function testGetChildrenReturnsAnRecursiveRoleIteratorOfRoleChildren()
+    {
+        $baz = new HierarchicalRole('Baz');
+        $baz->addChild(new Role('Foo'));
+        $baz->addChild(new Role('Bar'));
+
+        $roles    = [$baz];
+        $iterator = new RecursiveRoleIterator($roles);
+
+        $this->assertEquals(
+            $iterator->getChildren(),
+            new RecursiveRoleIterator($baz->getChildren())
+        );
+    }
+}

--- a/tests/RbacTest/Traversal/RecursiveRoleIteratorTest.php
+++ b/tests/RbacTest/Traversal/RecursiveRoleIteratorTest.php
@@ -53,7 +53,7 @@ class RecursiveRoleIteratorTest extends TestCase
     /**
      * @covers Rbac\Traversal\RecursiveRoleIterator::hasChildren
      */
-    public function testHasChildrenReturnsFalseIfRoleIsNotHierarchical()
+    public function testHasChildrenReturnsFalseIfCurrentRoleIsNotHierarchical()
     {
         $foo      = new Role('Foo');
         $roles    = [$foo];
@@ -65,11 +65,12 @@ class RecursiveRoleIteratorTest extends TestCase
     /**
      * @covers Rbac\Traversal\RecursiveRoleIterator::hasChildren
      */
-    public function testHasChildrenReturnsFalseIfRoleChildrenIsEmpty()
+    public function testHasChildrenReturnsFalseIfCurrentRoleHasNotChildren()
     {
-        $bar      = new HierarchicalRole('Bar');
-        $roles    = [$bar];
-        $iterator = new RecursiveRoleIterator($roles);
+        $role     = $this->getMock('Rbac\Role\HierarchicalRoleInterface');
+        $iterator = new RecursiveRoleIterator([$role]);
+
+        $role->expects($this->once())->method('hasChildren')->will($this->returnValue(false));
 
         $this->assertFalse($iterator->hasChildren());
     }
@@ -77,13 +78,12 @@ class RecursiveRoleIteratorTest extends TestCase
     /**
      * @covers Rbac\Traversal\RecursiveRoleIterator::hasChildren
      */
-    public function testHasChildrenReturnsTrueIfRoleHasChildren()
+    public function testHasChildrenReturnsTrueIfCurrentRoleHasChildren()
     {
-        $baz = new HierarchicalRole('Baz');
-        $baz->addChild(new Role('Foo'));
+        $role     = $this->getMock('Rbac\Role\HierarchicalRoleInterface');
+        $iterator = new RecursiveRoleIterator([$role]);
 
-        $roles    = [$baz];
-        $iterator = new RecursiveRoleIterator($roles);
+        $role->expects($this->once())->method('hasChildren')->will($this->returnValue(true));
 
         $this->assertTrue($iterator->hasChildren());
     }

--- a/tests/RbacTest/Traversal/RecursiveRoleIteratorTest.php
+++ b/tests/RbacTest/Traversal/RecursiveRoleIteratorTest.php
@@ -9,6 +9,7 @@
 
 namespace RbacTest\Traversal;
 
+use ArrayIterator;
 use PHPUnit_Framework_TestCase as TestCase;
 use Rbac\Role\HierarchicalRole;
 use Rbac\Role\Role;
@@ -21,6 +22,17 @@ use stdClass;
  */
 class RecursiveRoleIteratorTest extends TestCase
 {
+    /**
+     * @covers Rbac\Traversal\RecursiveRoleIterator::__construct
+     */
+    public function testAcceptTraversable()
+    {
+        $roles    = new ArrayIterator([new Role('foo'), new Role('bar')]);
+        $iterator = new RecursiveRoleIterator($roles);
+
+        $this->assertEquals($iterator->getArrayCopy(), $roles->getArrayCopy());
+    }
+
     /**
      * @covers Rbac\Traversal\RecursiveRoleIterator::valid
      */

--- a/tests/RbacTest/Traversal/Strategy/GeneratorStrategyTest.php
+++ b/tests/RbacTest/Traversal/Strategy/GeneratorStrategyTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace RbacTest\Traversal\Strategy;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Rbac\Role\HierarchicalRole;
+use Rbac\Role\Role;
+use Rbac\Traversal\Strategy\GeneratorStrategy;
+
+/**
+ * @covers Rbac\Traversal\Strategy\GeneratorStrategy
+ * @group  Coverage
+ */
+class GeneratorStrategyTest extends TestCase
+{
+    /**
+     * @covers Rbac\Traversal\Strategy\GeneratorStrategy::traverseRoles
+     */
+    public function testTraverseFlatRoles()
+    {
+        $strategy = new GeneratorStrategy;
+        $roles    = [new Role('Foo'), new Role('Bar')];
+
+        $this->assertEquals(
+            $roles,
+            iterator_to_array($strategy->traverseRoles($roles))
+        );
+    }
+
+    /**
+     * @covers Rbac\Traversal\Strategy\GeneratorStrategy::traverseRoles
+     */
+    public function testTraverseHierarchicalRoles()
+    {
+        $strategy = new GeneratorStrategy;
+
+        $child1 = new Role('child 1');
+        $child2 = new Role('child 2');
+        $child3 = new Role('child 3');
+
+        $parent1 = new HierarchicalRole('parent 1');
+        $parent1->addChild($child1);
+
+        $parent2 = new HierarchicalRole('parent 2');
+        $parent2->addChild($child2);
+
+        $parent3 = new HierarchicalRole('parent 3');
+        $parent3->addChild($child3);
+
+        $roles = [$parent1, $parent2, $parent3];
+
+        $expectedResult = [
+            $parent1, $child1,
+            $parent2, $child2,
+            $parent3, $child3,
+        ];
+
+        $this->assertEquals(
+            $expectedResult,
+            iterator_to_array($strategy->traverseRoles($roles))
+        );
+    }
+}

--- a/tests/RbacTest/Traversal/Strategy/GeneratorStrategyTest.php
+++ b/tests/RbacTest/Traversal/Strategy/GeneratorStrategyTest.php
@@ -15,8 +15,9 @@ use Rbac\Role\Role;
 use Rbac\Traversal\Strategy\GeneratorStrategy;
 
 /**
- * @covers Rbac\Traversal\Strategy\GeneratorStrategy
- * @group  Coverage
+ * @requires PHP 5.5.0
+ * @covers   Rbac\Traversal\Strategy\GeneratorStrategy
+ * @group    Coverage
  */
 class GeneratorStrategyTest extends TestCase
 {

--- a/tests/RbacTest/Traversal/Strategy/GeneratorStrategyTest.php
+++ b/tests/RbacTest/Traversal/Strategy/GeneratorStrategyTest.php
@@ -22,7 +22,7 @@ use Rbac\Traversal\Strategy\GeneratorStrategy;
 class GeneratorStrategyTest extends TestCase
 {
     /**
-     * @covers Rbac\Traversal\Strategy\GeneratorStrategy::traverseRoles
+     * @covers Rbac\Traversal\Strategy\GeneratorStrategy::getRolesIterator
      */
     public function testTraverseFlatRoles()
     {
@@ -31,12 +31,12 @@ class GeneratorStrategyTest extends TestCase
 
         $this->assertEquals(
             $roles,
-            iterator_to_array($strategy->traverseRoles($roles))
+            iterator_to_array($strategy->getRolesIterator($roles))
         );
     }
 
     /**
-     * @covers Rbac\Traversal\Strategy\GeneratorStrategy::traverseRoles
+     * @covers Rbac\Traversal\Strategy\GeneratorStrategy::getRolesIterator
      */
     public function testTraverseHierarchicalRoles()
     {
@@ -65,7 +65,7 @@ class GeneratorStrategyTest extends TestCase
 
         $this->assertEquals(
             $expectedResult,
-            iterator_to_array($strategy->traverseRoles($roles))
+            iterator_to_array($strategy->getRolesIterator($roles))
         );
     }
 }

--- a/tests/RbacTest/Traversal/Strategy/RecursiveRoleIteratorStrategyTest.php
+++ b/tests/RbacTest/Traversal/Strategy/RecursiveRoleIteratorStrategyTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace RbacTest\Traversal\Strategy;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Rbac\Role\Role;
+use Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy;
+
+/**
+ * @covers Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy
+ * @group  Coverage
+ */
+class RecursiveRoleIteratorStrategyTest extends TestCase
+{
+    /**
+     * @covers Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy::traverseRoles
+     */
+    public function testGetIterator()
+    {
+        $strategy      = new RecursiveRoleIteratorStrategy;
+        $roles         = [new Role('Foo'), new Role('Bar')];
+        $iterator      = $strategy->traverseRoles($roles);
+        $innerIterator = $iterator->getInnerIterator();
+
+        $this->assertInstanceOf('RecursiveIteratorIterator', $iterator);
+        $this->assertInstanceOf('Rbac\Traversal\RecursiveRoleIterator', $innerIterator);
+        $this->assertEquals($roles, $innerIterator->getArrayCopy());
+    }
+}

--- a/tests/RbacTest/Traversal/Strategy/RecursiveRoleIteratorStrategyTest.php
+++ b/tests/RbacTest/Traversal/Strategy/RecursiveRoleIteratorStrategyTest.php
@@ -20,13 +20,13 @@ use Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy;
 class RecursiveRoleIteratorStrategyTest extends TestCase
 {
     /**
-     * @covers Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy::traverseRoles
+     * @covers Rbac\Traversal\Strategy\RecursiveRoleIteratorStrategy::getRolesIterator
      */
     public function testGetIterator()
     {
         $strategy      = new RecursiveRoleIteratorStrategy;
         $roles         = [new Role('Foo'), new Role('Bar')];
-        $iterator      = $strategy->traverseRoles($roles);
+        $iterator      = $strategy->getRolesIterator($roles);
         $innerIterator = $iterator->getInnerIterator();
 
         $this->assertInstanceOf('RecursiveIteratorIterator', $iterator);


### PR DESCRIPTION
Finally! Sorry for the delay :D
# Traversal strategies

The [Graph traversal](http://en.wikipedia.org/wiki/Graph_traversal) is a very complex problem, there are several ways to do this, but none of them is the best way for all cases. There are many cases that need a specific algorithm. For instance, If you have a very dense role graph, you'll probably want to avoid redundancy when traversing the graph (checking the same role more than once). But if you have a flatter role graph, then you will not care about the redundancy, because the logic to avoid redundancy would be more costly than the redundancy itself.

So, if we make this algorithm pluggable, the RBAC component will become much more flexible, allowing the developers to easily implement their own strategies for specific cases.

I have many ideas for other strategies to implement (e.g a non-redundant generator strategy), but for now I'll suggest two:
### Built-in traversal strategies:
- **RecursiveRoleIteratorStrategy** - The default strategy, it recursively traverses the roles using a SPL `RecursiveIteratorIterator` that iterate over instances of `Rbac\Traversal\RecursiveRoleIterator`.
- **GeneratorStrategy** - This strategy requires PHP >= 5.5, the fastest and lightweight strategy! It takes advantage of the new PHP 5.5 generators to recursively traverse the role graph. 
### Benchmarks

I did some performance tests of the built-in strategies to know which one is faster. You can run the benchmarks yourself, just follow the instructions in the [danizord/rbac-benchmarks](https://github.com/danizord/rbac-benchmarks) repository. See the results on my PC:

```
daniel@Danibook:~/projects/rbac-benchmarks$ php vendor/bin/athletic -p src/ -b vendor/autoload.php

Danizord\RbacBenchmarks\Traversal\GeneratorStrategyEvent
    Method Name                   Iterations    Average Time      Ops/second
    ---------------------------  ------------  --------------    -------------
    flatFirstMatch             : [1,000     ] [0.0000078084469] [128,066.44072]
    flatLastMatch              : [1,000     ] [0.0000445151329] [22,464.27079]
    hierarchicalFirstDepthMatch: [1,000     ] [0.0000128533840] [77,800.52308]
    hierarchicalLastDepthMatch : [1,000     ] [0.0000390281677] [25,622.51979]


Danizord\RbacBenchmarks\Traversal\RecursiveIteratorStrategyEvent
    Method Name                   Iterations    Average Time      Ops/second
    ---------------------------  ------------  --------------    -------------
    flatFirstMatch             : [1,000     ] [0.0000188462734] [53,060.88783]
    flatLastMatch              : [1,000     ] [0.0000955798626] [10,462.45488]
    hierarchicalFirstDepthMatch: [1,000     ] [0.0000269591808] [37,093.11519]
    hierarchicalLastDepthMatch : [1,000     ] [0.0000535430908] [18,676.54602]
```
## Additional changes
- `HierarchicalRoleInterface` no longer extends `RecursiveIterator`, this means that the roles are not aware of traversal nor recursion anymore.
- The recursive iteration that was previously in `HierarchicalRole`, now is done in the new `RecursiveRoleIterator`.
- `Rbac::isGranted()` now now accepts a collection/array of `RoleInterface`s, but still accepting a single `RoleInterface` instance. If one of the given roles has the required permission, then it returns `true`.
- Some tests was updated, the code coverage of this component is now 100%. :smiley: 
